### PR TITLE
Support mirakc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,31 @@ Carthage/Build
 Carthage/Checkouts
 Meruru.xcodeproj/xcuserdata
 
+# Xcode
+#
+# gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
+
+## User settings
+xcuserdata/
+
+## compatibility with Xcode 8 and earlier (ignoring not required starting Xcode 9)
+*.xcscmblueprint
+*.xccheckout
+
+## compatibility with Xcode 3 and earlier (ignoring not required starting Xcode 4)
+build/
+DerivedData/
+*.moved-aside
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+
+## Gcc Patch
+/*.gcno
+
+.DS_Store

--- a/Cartfile
+++ b/Cartfile
@@ -1,3 +1,2 @@
 binary "https://code.videolan.org/videolan/VLCKit/raw/master/Packaging/VLCKit.json" ~> 3.3.0
-github "Alamofire/Alamofire" "5.0.0-beta.3"
-
+github "Alamofire/Alamofire" ~> 5.2

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-binary "https://code.videolan.org/videolan/VLCKit/raw/master/Packaging/VLCKit.json" "3.3.1"
-github "Alamofire/Alamofire" "5.0.0-beta.3"
+binary "https://code.videolan.org/videolan/VLCKit/raw/master/Packaging/VLCKit.json" "3.3.16"
+github "Alamofire/Alamofire" "5.4.1"

--- a/Meruru/AppDelegate.swift
+++ b/Meruru/AppDelegate.swift
@@ -37,7 +37,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSComboBoxDelegate {
             case .success(let status):
                 AppConfig.shared.currentData?.mirakurunPath = mirakurunPath
                 DispatchQueue.main.async {
-                    self.statusTextField.stringValue = "Mirakurun: v" + status.version
+                    self.statusTextField.stringValue = "Mirakurun: v" + (status.version ?? " unknown")
                 }
                 self.mirakurun.fetchServices { result in
                     switch result {

--- a/Meruru/MirakurunAPI.swift
+++ b/Meruru/MirakurunAPI.swift
@@ -10,7 +10,7 @@ import Foundation
 import Alamofire
 
 public struct Status: Codable {
-    let version: String
+    let version: String?
 }
 
 public struct Service: Codable {

--- a/Meruru/MirakurunAPI.swift
+++ b/Meruru/MirakurunAPI.swift
@@ -52,13 +52,17 @@ public class MirakurunAPI {
     }
     
     public func getStreamURL(service: Service) -> URL {
-        return self.baseURL
+        let queryItems = [URLQueryItem(name: "decode", value: "1")]
+        let streamUrl = self.baseURL
             .appendingPathComponent("channels")
             .appendingPathComponent(service.channel.type)
             .appendingPathComponent(service.channel.channel)
             .appendingPathComponent("services")
             .appendingPathComponent(String(service.serviceId))
             .appendingPathComponent("stream")
+        var urlComps = URLComponents(url: streamUrl, resolvingAgainstBaseURL: false)
+        urlComps?.queryItems = queryItems
+        return (urlComps?.url)!
     }
     
     public func fetchStatus(completion: @escaping (Result<Status, AFError>) -> Void) {

--- a/Meruru/MirakurunAPI.swift
+++ b/Meruru/MirakurunAPI.swift
@@ -40,7 +40,7 @@ public class MirakurunAPI {
     private let baseURL: URL
     private let jsonDecoder: JSONDecoder = JSONDecoder()
     
-    public func fetchPrograms(service: Service, completion: @escaping (Result<[Program]>) -> Void) {
+    public func fetchPrograms(service: Service, completion: @escaping (Result<[Program], AFError>) -> Void) {
         let url = self.baseURL.appendingPathComponent("programs")
         let params: Parameters = [
             "serviceId": service.serviceId,
@@ -61,14 +61,14 @@ public class MirakurunAPI {
             .appendingPathComponent("stream")
     }
     
-    public func fetchStatus(completion: @escaping (Result<Status>) -> Void) {
+    public func fetchStatus(completion: @escaping (Result<Status, AFError>) -> Void) {
         let url = self.baseURL.appendingPathComponent("status")
         AF.request(url).responseDecodable { response in
             completion(response.result)
         }
     }
     
-    public func fetchServices(completion: @escaping (Result<[Service]>) -> Void) {
+    public func fetchServices(completion: @escaping (Result<[Service], AFError>) -> Void) {
         let url = self.baseURL.appendingPathComponent("services")
         AF.request(url).responseDecodable { response in
             completion(response.result)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Meruru
 
-A Simple [Mirakurun](https://github.com/Chinachu/Mirakurun) Client for Mac OS
+A Simple [Mirakurun](https://github.com/Chinachu/Mirakurun)/[mirakc](https://github.com/mirakc/mirakc) Client for Mac OS
 
 ![Meruru](Meruru.png)
 
@@ -13,7 +13,7 @@ Config file: `~/.config/meruru/config.json`
 ## Build
 
 - Install [Carthage](https://github.com/Carthage/Carthage)
-- Run `carthage install`
+- Run `carthage bootstrap`
 
 ## License
 


### PR DESCRIPTION
### 変更内容
1. [mirakc](https://github.com/mirakc/mirakc)への対応
2. dependencyのアップデート
3. readmeの更新

### 詳細
1. mirakcへ対応しました。少し古いですが0.15.0での動作確認済みです。  
対応としては `<URL>?decode=1` のパラメータ追加、`/api/status`の動作の違い（mirakcは何も返さない）があるのでmirakcの場合はバージョン情報を切り捨てる対応をしました。
対応コミット: 177e1f3, 97971e6
2. alamofireを5.0.0-beta3から5.4.1へ、VLCKitを3.3.1から3.3.16へアップデートしました。  
almofireのみアップデートに伴う引数の変更がありました。   
対応コミット: d18953c e5c3df8  
3. Readmeにmirakcを追加し、carthageの使用方法を修正しました
対応コミット:  9e30edd


mirakcにて使用したいために修正しました。
せっかくなのでプルリクエスト送ります。

注意点としてmirakurunでの動作確認をしていません。
API見る限り問題ないと思いますが確認可能なら確認をお願いしたいです。
