### PR TITLE
mirakc向けにStatus APIをVersion APIに移行する

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
-binary "https://code.videolan.org/videolan/VLCKit/raw/master/Packaging/VLCKit.json" ~> 3.3.0
-github "Alamofire/Alamofire" ~> 5.2
+binary "https://code.videolan.org/videolan/VLCKit/raw/master/Packaging/VLCKit.json" ~> 3.5.1
+github "Alamofire/Alamofire" ~> 5.6.4

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-binary "https://code.videolan.org/videolan/VLCKit/raw/master/Packaging/VLCKit.json" "3.3.16"
-github "Alamofire/Alamofire" "5.4.1"
+binary "https://code.videolan.org/videolan/VLCKit/raw/master/Packaging/VLCKit.json" "3.5.1"
+github "Alamofire/Alamofire" "5.6.4"

--- a/Meruru/AppDelegate.swift
+++ b/Meruru/AppDelegate.swift
@@ -32,12 +32,12 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSComboBoxDelegate {
         }
 
         mirakurun = MirakurunAPI(baseURL: URL(string: mirakurunPath + "/api")!)
-        mirakurun.fetchStatus { result in
+        mirakurun.fetchVersion { result in
             switch result {
             case .success(let status):
                 AppConfig.shared.currentData?.mirakurunPath = mirakurunPath
                 DispatchQueue.main.async {
-                    self.statusTextField.stringValue = "Mirakurun: v" + (status.version ?? " unknown")
+                    self.statusTextField.stringValue = "Mirakurun: v" + (status.current)
                 }
                 self.mirakurun.fetchServices { result in
                     switch result {

--- a/Meruru/MirakurunAPI.swift
+++ b/Meruru/MirakurunAPI.swift
@@ -9,8 +9,9 @@
 import Foundation
 import Alamofire
 
-public struct Status: Codable {
-    let version: String?
+public struct Version: Codable {
+    let current: String
+    let latest: String
 }
 
 public struct Service: Codable {
@@ -65,8 +66,8 @@ public class MirakurunAPI {
         return (urlComps?.url)!
     }
     
-    public func fetchStatus(completion: @escaping (Result<Status, AFError>) -> Void) {
-        let url = self.baseURL.appendingPathComponent("status")
+    public func fetchVersion(completion: @escaping (Result<Version, AFError>) -> Void) {
+        let url = self.baseURL.appendingPathComponent("version")
         AF.request(url).responseDecodable { response in
             completion(response.result)
         }


### PR DESCRIPTION
# 内容

mirakcのStatus APIが何も返さないため、mirakcでも実装されているVersion APIに移行する

# 参考
- https://github.com/mirakc/mirakc/blob/main/docs/web-api.md#get-apiversion
- https://github.com/Chinachu/Mirakurun/blob/master/api.yml#L567
